### PR TITLE
Update the code to the new API of path.py

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - python
-    - path.py ==8.2.1
+    - path.py
     - gitpython
     - pyyaml
 

--- a/example/tuto01/config.yaml
+++ b/example/tuto01/config.yaml
@@ -3,7 +3,6 @@ packages:
       vcs       : git
       url       : https://github.com/revesansparole/VersionClimber_test1.git
       cmd       : pip install --no-index --no-deps -U
-      #directory : git_cache
 
 run:
     - python test_function.py

--- a/versionclimber/config.py
+++ b/versionclimber/config.py
@@ -5,11 +5,11 @@ This module implements a Package object that can retrieve the versions and activ
 
 import yaml
 import logging
-from path import path
-from versionclimber.utils import sh, pypi_versions, git_versions, svn_versions
 
 from string import Template
 import re
+
+from versionclimber.utils import sh, pypi_versions, git_versions, svn_versions, Path
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,12 @@ class Package(object):
         self.version = version
         self.hierarchy = hierarchy
         self.conda = bool(conda)
-        self.dir = path(directory).abspath()
-        self.recipe_dir = path(recipe).abspath()
+        self.dir = Path(directory).abspath()
+        if conda and recipe:
+            self.recipe_dir = Path(recipe).abspath()
+        else:
+            self.recipe_dir = None
+
         if not self.dir.exists():
             self.dir.makedirs()
 
@@ -43,10 +47,10 @@ class Package(object):
         return self.name
 
     def clone(self):
-        cwd = path('.').abspath()
+        cwd = Path('.').abspath()
 
         if self.vcs == 'path':
-            path_pkg = path(self.url).abspath()
+            path_pkg = Path(self.url).abspath()
 
         pp = self.dir/self.name
         if pp.exists():
@@ -108,7 +112,7 @@ class Package(object):
 
     def checkout_update(self, commit):
         pp = self.dir/self.name
-        cwd = path('.').abspath()
+        cwd = Path('.').abspath()
 
         commit = str(commit)
 

--- a/versionclimber/liquid.py
+++ b/versionclimber/liquid.py
@@ -9,7 +9,7 @@ import itertools
 import logging
 
 # import git
-from .utils import sh, path, new_stat_file, clock
+from .utils import sh, Path, new_stat_file, clock
 from . import multigit
 from .version import take, hversions
 from .config import load_config
@@ -35,9 +35,9 @@ class Environment(object):
                     self.d[pkg].insert(0,endof[pkg])
 
         self.universe = self.d.keys()
-        self.curdir = path('.').abspath()
+        self.curdir = Path('.').abspath()
 
-        self.pkg_dir = path(dir)
+        self.pkg_dir = Path(dir)
 
         self.branch_names = multigit.branch_names(env.pkg_dir, universe)
         self.error_file = 'error.txt'
@@ -180,7 +180,7 @@ def parse_error(error_file):
     lines = lines[-i - 1:]
     l = lines[0]
     filename = l.split(',')[0].split(' ')[-1].strip('"')
-    src = str(path(filename).namebase)
+    src = str(Path(filename).namebase)
     msg = '\n'.join(lines[1:])
     for pkg in env.universe:
         if pkg in msg:
@@ -368,9 +368,9 @@ class MyEnv(object):
 
         self.d = self.commits = versions  # multigit.universe_versions(dir, universe, Tags=Tags)
         self.universe = universe
-        # self.curdir = path('.').abspath()
+        # self.curdir = Path('.').abspath()
 
-        # self.pkg_dir = path(dir)
+        # self.pkg_dir = Path(dir)
 
         # self.branch_names = multigit.branch_names(env.pkg_dir, universe)
         # self.error_file = 'error.txt'
@@ -480,11 +480,11 @@ class YAMLEnv(MyEnv):
         cmd = self.cmd
 
         status = sh(cmd)
-        if path(self.error_file).exists():
+        if Path(self.error_file).exists():
             if liquidparser.knowcaller:
                 return parse_error(self.error_file)
             else:
-                path(self.error_file).move(curdir/'errors'/self.error_file+str(count))
+                Path(self.error_file).move(curdir/'errors'/self.error_file+str(count))
                 return -1, -1
         else:
             return status

--- a/versionclimber/multigit.py
+++ b/versionclimber/multigit.py
@@ -5,7 +5,10 @@ Task 3: Report the version graph for each particular package
 
 import os
 import git
-from path import path
+try:
+    from path import Path
+except ImportError:
+    from path import path as Path
 
 
 def versions(path):
@@ -52,7 +55,7 @@ def tags(path):
 def test():
     from versionclimber.utils import path, clone
 
-    pkgs = path('pkgs').abspath()
+    pkgs = Path('pkgs').abspath()
 
 
     sklearn = ('scikit-learn', 'scikit-learn')
@@ -75,7 +78,7 @@ def test():
     return _tags, _versions
 
 def universe_versions(dir='simple', universe=('foo', 'goo', 'hoo'), Tags=False):
-    pkgs = path(dir).abspath()
+    pkgs = Path(dir).abspath()
 
     res = {}
     for pkg in universe:
@@ -88,7 +91,7 @@ def universe_versions(dir='simple', universe=('foo', 'goo', 'hoo'), Tags=False):
     return res
 
 def branch_names(dir='simple', universe=('foo', 'goo', 'hoo')):
-    _dir = path(dir)
+    _dir = Path(dir)
 
     res = {}
     for pkg in universe:

--- a/versionclimber/utils.py
+++ b/versionclimber/utils.py
@@ -3,7 +3,11 @@
 """
 
 import os
-from path import path
+try:
+    from path import Path
+except ImportError:
+    from path import path as Path
+
 import subprocess
 import re
 import json
@@ -26,7 +30,7 @@ def sh(cmd):
 
 
 def new_stat_file(exp='experiment'):
-    exp = path(exp)
+    exp = Path(exp)
     def next_id(exp=exp):
         l = [int(x.basename().split('result')[1][0]) for x in exp.listdir('result*.txt')]
         n = max(l)+1 if l else 1
@@ -67,8 +71,8 @@ def svn_versions(package_path):
     """ Extract all the svn versions of a given directory
 
     """
-    cwd = path('.').abspath()
-    pp = path(package_path)
+    cwd = Path('.').abspath()
+    pp = Path(package_path)
     if pp.exists():
         pp.chdir()
     else:


### PR DESCRIPTION
The interface of path.py has changed.
Rather than using path.path, you have to use path.Path.
This modification breaks version climber when using with the last path.py versions (> 8.2.1).
The code is now modified to use both conventions.