### PR TITLE
 Use generators for traversing the set of possible PackageVersions

### DIFF
--- a/versionclimber/algo/demandsupply.py
+++ b/versionclimber/algo/demandsupply.py
@@ -329,7 +329,7 @@ def liquidclimber(miniseries, packageversions, anchorFlag=True):
   i = 0
   bestanchor = []
   while (i < nb_configs) and notDone:
-    c = list(configs.next())
+    c = list(next(configs))
     i = i+1
     if tryconfig(c) == 1:
       notDone = False

--- a/versionclimber/algo/demandsupply.py
+++ b/versionclimber/algo/demandsupply.py
@@ -98,7 +98,9 @@ def mycrossproduct_iter(packageversions):
   # by varying the latest one
   gen = itertools.product(*iterators)
 
-  nb_versions = reduce(lambda x, y: x*y, map(len, packageversions))
+  nb_versions = 1
+  for pkgvers in packageversions:
+    nb_versions *= len(pkgvers)
 
   return nb_versions, gen
 

--- a/versionclimber/liquid.py
+++ b/versionclimber/liquid.py
@@ -28,6 +28,8 @@ from collections import OrderedDict
 logger = logging.getLogger(__name__)
 
 STAT_FILE = False
+
+# TODO: Define ANCHOR as an optional parameter of vclimb
 ANCHOR = True
 
 
@@ -492,13 +494,13 @@ class YAMLEnv(MyEnv):
         """
         # TODO : Move the main code in a new object PackageSet
 
-        print(semantic_config)
+        #print(semantic_config) # log this
         pkg_names= list(semantic_config.keys())
         commits = list(semantic_config.values())
         pkgs =  [self.pkg_names[pn] for pn in pkg_names]
         versions = [commit for i, commit in enumerate(commits)]
 
-        print('versions', versions)
+        #print('versions', versions) # log this
 
         conda_pkgs = [(i, pkg) for i, pkg in enumerate(pkgs) if pkg.vcs == 'conda']
         other_pkgs = [(i, pkg) for i, pkg in enumerate(pkgs) if pkg.vcs != 'conda']
@@ -774,8 +776,8 @@ class YAMLEnv(MyEnv):
 
         try:
             if self.algo_demandsupply:
-                print("PackageVersions", packageversions)
-                print("miniseries", miniseries)
+                # print("PackageVersions", packageversions) # log this
+                # print("miniseries", miniseries) # log this
                 endconfig = liquidparser.liquidclimber(miniseries, packageversions, ANCHOR)
 
             else:
@@ -861,6 +863,7 @@ class YAMLEnv(MyEnv):
                 print('Supply-constant Versions of ', name)
                 print('-'*(12+len(name)))
                 for _version in v_dict:
-                    print('Supply-constant ', ' '.join(v_dict[_version]))
+                    constant = 'Supply-constant ' if name != 'python' else 'Demand-constant '
+                    print(constant, ' '.join(v_dict[_version]))
 
 


### PR DESCRIPTION
Use generators instead of building the full set of possible versions in memory.
This enhance mainly the memory cost for very large potential configurations